### PR TITLE
feat: setup publish.yml for automated NuGet deployment (#24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,5 @@
 name: CI
 
-# Запуск при:
-# - Открытии/обновлении PR в main/staging
-# - Прямом пуше в main/staging
 on:
   pull_request:
     branches: [ main, staging ]
@@ -27,13 +24,32 @@ jobs:
       - name: 🔁 Checkout code
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0  # Для MinVer и правильной истории тегов
+          fetch-depth: 0  # Критично для MinVer
+
+      # DEBUG: Диагностика .git и тегов — можно удалить после настройки
+      - name: "🧪 DEBUG: Check git and tags (safe to remove later)"
+        run: |
+          echo "🔍 Git directory:"
+          ls -la .git || echo "❌ .git not found"
+          
+          echo "📡 Fetching all tags..."
+          git fetch --prune --tags --verbose
+          
+          echo "📦 Available tags (latest 10):"
+          git tag --list --sort=-version:refname | head -10
+          
+          if git tag --list | grep -q "^v1\.2\.0$"; then
+            echo "✅ Tag v1.2.0 is present"
+          else
+            echo "❌ Tag v1.2.0 is MISSING — MinVer may fallback to 1.1.0"
+          fi
+        # DEBUG: Удалить после подтверждения стабильности
 
       - name: ⚙️ Setup .NET ${{ matrix.dotnet-version }}
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
-          cache: false  # Мы сами кэшируем пакеты
+          cache: false
 
       - name: 💾 Cache NuGet packages
         uses: actions/cache@v5
@@ -54,20 +70,33 @@ jobs:
 
       - name: 🔨 Build library
         run: |
+          echo "🔨 Building MoneyToWords..."
           dotnet build src/MoneyToWords/MoneyToWords.fsproj \
             --configuration Release \
             --no-incremental \
             --no-restore
 
+      # Уверенность, что MinVer сработал — по выводу из сборки
+      - name: ✅ Confirm MinVer output from build
+        run: |
+          echo "✅ MinVer should have printed version during build:"
+          echo "    Example: 🔖 Version: 1.2.1-alpha.4"
+          echo "💡 If you see it above — MinVer is working."
+          echo "❗ If not — check Directory.Build.props and git tags."
+
       - name: 🧪 Run tests
         run: |
           echo "🧪 Running tests..."
           mkdir -p TestResults
-          dotnet test tests/MoneyToWords.Tests/MoneyToWords.Tests.fsproj \
-            --configuration Release \
-            --no-build \
-            --verbosity normal \
-            --logger "trx;LogFileName=${{ github.workspace }}/TestResults/results.trx"
+          dotnet test tests/MoneyToWords.Tests/MoneyToWords.Tests.fsproj --configuration Release --verbosity normal --logger "trx;LogFileName=${{ github.workspace }}/TestResults/results.trx"
+
+      - name: 📤 Upload test results (if failed)
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v6
+        with:
+          name: test-results
+          path: TestResults/results.trx
+          retention-days: 5
 
       - name: 📦 Validate package (PR only)
         if: github.event_name == 'pull_request'
@@ -82,21 +111,21 @@ jobs:
             /p:ContinuousIntegrationBuild=true \
             /p:NoWarn=NU5128
 
-          echo "🔖 Detected version:"
-          dotnet msbuild -nologo -getProperty:PackageVersion /p:DesignTimeBuild=true
+          echo "🔖 Final PackageVersion:"
+          dotnet msbuild -nologo -getProperty:PackageVersion /p:DesignTimeBuild=true src/MoneyToWords/MoneyToWords.fsproj
 
           ls -la ./artifacts/
 
-      - name: 📤 Upload test results (if failed)
-        if: always() && github.event_name == 'pull_request'
+      - name: 📤 Upload validated package
+        if: github.event_name == 'pull_request' && success()
         uses: actions/upload-artifact@v6
         with:
-          name: test-results
-          path: TestResults/
+          name: validated-package
+          path: ./artifacts/*.nupkg
           retention-days: 5
 
   # ===================================================================
-  # Проверка лейблов (остаётся отдельно — нужна до всего)
+  # Проверка лейблов
   # ===================================================================
   validate-pr:
     if: github.event_name == 'pull_request'
@@ -121,13 +150,13 @@ jobs:
             exit 1
           fi
 
-          # (вставь сюда свой существующий скрипт проверки)
-          # или оставь как есть — он уже работает
+          # Твой существующий скрипт проверки лейблов
+          # (оставь как есть — он работает)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # ===================================================================
-  # Публикация (остаётся без изменений)
+  # Публикация
   # ===================================================================
   publish:
     if: github.event_name == 'release' && github.event.action == 'published'
@@ -161,13 +190,16 @@ jobs:
       - name: 🛰️ Fetch all tags
         run: |
           git fetch --prune --tags
-          git tag --list --sort=-version:refname | head -5
+          echo "📦 Tags available:"
+          git tag --list --sort=-version:refname | head -10
 
-      - name: "🧪 Debug: Show MinVer version"
+      - name: 🔧 Restore and Build
         run: |
-          MINVER=$(dotnet msbuild -nologo -getProperty:MinVerVersion /p:DesignTimeBuild=true)
-          echo "🔖 MinVerVersion: $MINVER"
-          [ -z "$MINVER" ] && exit 1
+          dotnet restore --force-evaluate
+          dotnet build src/MoneyToWords/MoneyToWords.fsproj \
+            --configuration Release \
+            /p:RepositoryUrl=https://github.com/DivinMA/MoneyToWords \
+            /bl:build.binlog
 
       - name: 📦 Pack with MinVer
         id: pack
@@ -179,8 +211,11 @@ jobs:
             /p:SymbolPackageFormat=snupkg \
             /p:ContinuousIntegrationBuild=true
 
-      - name: 📦 Verify packaged version
+      - name: ✅ Verify package version and contents
         run: |
+          echo "📦 Final version:"
+          dotnet msbuild -nologo -getProperty:PackageVersion
+          ls -la ./artifacts/
           find ./artifacts -name "*.nupkg" -exec echo "✅ Created package:" {} \;
 
       - name: Publish to NuGet.org

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,84 @@
+name: 🚀 Publish NuGet Package
+
+# Запускается ТОЛЬКО при публикации релиза
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    # Гарантируем: только из main
+    if: github.event.release.target_commitish == 'main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write  # Для сборки с идентификацией
+
+    steps:
+      - name: 🔁 Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # Критично для MinVer
+
+      - name: ⚙️ Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: 💾 Cache NuGet packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: 🧹 Remove packages.lock.json (workaround)
+        run: |
+          find . -name "packages.lock.json" -type f -delete || true
+
+      - name: 🛰️ Fetch all tags
+        run: |
+          git fetch --prune --tags
+          echo "📦 Available tags:"
+          git tag --list --sort=-version:refname | head -10
+
+      - name: 🔧 Restore dependencies
+        run: |
+          dotnet restore --force-evaluate
+
+      - name: 🔨 Build project
+        run: |
+          dotnet build src/MoneyToWords/MoneyToWords.fsproj \
+            --configuration Release \
+            /p:RepositoryUrl=https://github.com/DivinMA/MoneyToWords \
+            /bl:build.binlog
+
+      - name: 📦 Pack with MinVer
+        run: |
+          dotnet pack src/MoneyToWords/MoneyToWords.fsproj \
+            --configuration Release \
+            --output ./artifacts \
+            /p:IncludeSymbols=true \
+            /p:SymbolPackageFormat=snupkg \
+            /p:ContinuousIntegrationBuild=true
+
+      - name: ✅ Verify package version
+        run: |
+          echo "🔖 Final PackageVersion:"
+          dotnet msbuild -nologo -getProperty:PackageVersion
+          ls -la ./artifacts/
+          find ./artifacts -name "*.nupkg" -exec echo "✅ Created package:" {} \;
+
+      - name: Publish to NuGet.org
+        run: |
+          dotnet nuget push "./artifacts/*.nupkg" \
+            --source https://api.nuget.org/v3/index.json \
+            --api-key ${{ secrets.NUGET_API_KEY }} \
+            --skip-duplicate
+
+      - name: Attach package to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ./artifacts/*.nupkg
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/MoneyToWords/MoneyToWords.fsproj
+++ b/src/MoneyToWords/MoneyToWords.fsproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     
     <PropertyGroup>
         <!-- Только здесь! -->


### PR DESCRIPTION
* refactor(ci): merge build/test/pack into single job (#22) (#23)

refactor(ci): merge build/test/pack into single job

- Объединены build, test и pack-validation в один job для упрощения и надёжности
- Устранены ошибки парсинга команд в CI за счёт однострочных dotnet вызовов
- Исправлена диагностика MinVer: теперь версия корректно определяется как 1.2.1-alpha.4
- Добавлена отладочная информация по git-тегам и состоянию репозитория
- Пакет успешно собирается и валидируется в PR
- Исправлена ошибка MSB1063: добавлен явный путь к .fsproj при getProperty

CI теперь стабилен, готов к автоматической публикации новых версий.


* fix(ci): remove --no-build to fix test execution

* fix(ci): remove inline comment to fix shell syntax

* chore(ci): add full debug info for MinVer and CI

* fix(ci): force MinVer evaluation via real build

* feat: add MinVer PackageReference to enable version detection

* chore(ci): simplify and stabilize CI with working MinVer

* fix(ci): fix yaml syntax by removing UI artifacts

* fix(ci): specify project file for msbuild getProperty

* feat: add dedicated publish workflow for NuGet releases

Closes: #24 